### PR TITLE
Add missing '/' slash to version-tagged download link

### DIFF
--- a/_includes/nhsl-resources.html
+++ b/_includes/nhsl-resources.html
@@ -39,7 +39,7 @@
         </div>
       </form>
     </div>
-  </div>     
+  </div>
 {% endcapture %}
 
 {% assign resrcs = "" %}
@@ -52,7 +52,7 @@
                 {% assign download_link = resource.link %}
             {% else %}
                 {% capture download_link %}
-                {{site.github.releases_url}}/download{{site.github.releases[0].tag_name}}/{{resource.link}}
+                {{site.github.releases_url}}/download/{{site.github.releases[0].tag_name}}/{{resource.link}}
                 {% endcapture %}
             {% endif %}
             {% if resource.region == 'ca' and resource.language contains include.lang %}


### PR DESCRIPTION
See https://github.com/OpenDRR/data/issues/54#issuecomment-894365917

---

By the way, really impressive work on rewriting the pages using Liquid template, @DamonU2!
And I really like that the download link is now in one place instead of scattered across multiple Markdown pages!  Thank you Damon!

And my apologies for have causing some merge conflicts especially because I added a commit without checking your PR first.  :sweat_smile:

@jvanulde I am seeing the "double slash" (actually missing release tag) on the resulting GitHub Pages in my fork too, e.g. https://anthonyfok.github.io/data/en/nhsl.html , though interestingly, the release tag is there when `bundle exec jekyll serve` is run locally, and fortunately the release tag is also intact on opendrr.github.io/data when pushed to OpenDRR/data.